### PR TITLE
Partial resolves issue with dynamic loading of ibverbs, mxm or hcol

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,20 @@ else
 fi
 
 
+##########################
+# Enable internal check
+#
+AC_ARG_ENABLE(
+    [check],
+    [AC_HELP_STRING([--enable-check],
+                   [IBPROF: turn on internal checking (default=yes)])],
+    [enable_check=$enableval],
+    [enable_check=yes])
+if test x$enable_check = xyes; then
+    CFLAGS="$CFLAGS -DHAVE_CHECK"
+fi
+
+
 #####################################
 # Checks for header files.
 #

--- a/src/api/ibprof_api.c
+++ b/src/api/ibprof_api.c
@@ -62,6 +62,9 @@ static IBPROF_MODULE_OBJECT *__ibprof_modules[] = {
 static IBPROF_OBJECT *ibprof_obj = NULL;	/* Verify a pointer to this object with NULL to check ACTIVE/CLOSE */
 pthread_once_t ibprof_initialized = PTHREAD_ONCE_INIT;
 
+#if defined(HAVE_VISIBILITY)
+#pragma GCC visibility push(default)
+#endif
 
 inline double ibprof_timestamp(void)
 {
@@ -144,6 +147,10 @@ void ibprof_dump(void)
 		format_dump(ibprof_dump_file, ibprof_obj);
 	}
 }
+
+#if defined(HAVE_VISIBILITY)
+#pragma GCC visibility pop
+#endif
 
 /****************************************************************************
  * Static Function Declarations
@@ -230,6 +237,7 @@ static double __get_cpu_clocks_per_sec(void)
 /****************************************************************************
  * Load/unload open/exit
  ***************************************************************************/
+
 
 /*
  * Shared object initializer.

--- a/src/api/ibprof_api.h
+++ b/src/api/ibprof_api.h
@@ -22,9 +22,6 @@
 extern "C" {
 #endif
 
-#if defined(HAVE_VISIBILITY)
-#pragma GCC visibility push(default)
-#endif
 
 /**
  * @enum
@@ -114,9 +111,6 @@ void ibprof_interval_end(int callid);
  ***************************************************************************/
 void ibprof_dump(void);
 
-#if defined(HAVE_VISIBILITY)
-#pragma GCC visibility pop
-#endif
 
 #ifdef __cplusplus
 }

--- a/src/cmn/ibprof_cmn.c
+++ b/src/cmn/ibprof_cmn.c
@@ -12,6 +12,78 @@
 
 FILE *ibprof_dump_file;
 
+/* This code is a workaround to RTLD_NEXT unexpected behaivour */
+static const char *_libname = NULL;
+static int _libname_counter = 0;
+
+
+void *sys_dlsym(const char *symname, const char *symver)
+{
+	void *symaddr = NULL;
+        const char *err = NULL;
+#if defined(__LINUX__)
+	void *libc_handle = RTLD_NEXT;
+again:
+	dlerror(); /* Clear any existing error */
+	if (NULL == symver)
+	symaddr = dlsym(libc_handle, symname);
+	else
+	symaddr = dlvsym(libc_handle, symname, symver);
+
+	err = dlerror();
+	if (!symaddr || err) {
+		/* This code is a workaround to RTLD_NEXT unexpected behaivour */
+		if (libc_handle == RTLD_NEXT) {
+#ifndef __COVERITY__
+			/* If the same library is loaded again with dlopen(), the same library
+			 * handle is returned
+			 */
+			dlerror();    /* Clear any existing error */
+			libc_handle = dlopen(_libname, RTLD_LAZY);
+			err = dlerror();
+			if (libc_handle && !err) {
+				if (_libname_counter > 0) {
+					dlclose(libc_handle);
+				}
+				_libname_counter++;
+				goto again;
+			}
+#endif /* __COVERITY__ */
+		}
+		IBPROF_TRACE("Can't resolve %s: %s\n", symname, err);
+	}
+#else
+#endif
+
+	return symaddr;
+}
+
+int sys_dlcheck(const char *libname)
+{
+	int ret = IBPROF_ERR_NONE;
+	void *libc_handle = NULL;
+	const char *err = NULL;
+#if defined(__LINUX__)
+	dlerror();    /* Clear any existing error */
+	libc_handle = dlopen(libname, RTLD_LAZY);
+
+	err = dlerror();
+	if (!libc_handle || err) {
+		IBPROF_WARN("Can't find %s: %s\n", libname, err);
+		ret = IBPROF_ERR_NOT_EXIST;
+	}
+
+	if (libc_handle) {
+                _libname = libname;
+                _libname_counter = 0;
+		dlclose(libc_handle);
+	}
+#else
+#endif
+
+	return ret;
+}
+
 /**
  * sys_hexdump
  *

--- a/src/core/hcol/ibprof_hcol.h
+++ b/src/core/hcol/ibprof_hcol.h
@@ -85,6 +85,7 @@
     EMPLOY_TYPE(func_name) *f;                                          \
     f = hcol_module_context.noble.func_name;                            \
     PRE_##type(func_name)                                               \
+    INTERNAL_CHECK();                                                   \
     ret = f(__VA_ARGS__);                                               \
     POST_RET_##type(func_name)                                          \
     PRETEND_USED(flip_ret);                                             \
@@ -95,6 +96,7 @@
     EMPLOY_TYPE(func_name) *f;                                          \
     f = hcol_module_context.noble.func_name;                            \
     PRE_##type(func_name)                                               \
+    INTERNAL_CHECK();                                                   \
     f(__VA_ARGS__);                                                     \
     POST_##type(func_name)                                              \
     PRETEND_USED(flip_ret);
@@ -105,6 +107,7 @@
     EMPLOY_TYPE(func_name) *f;                                          \
     f = hcol_module_context.noble.func_name;                            \
     PRE_##type(func_name)                                               \
+    INTERNAL_CHECK();                                                   \
     ret = f(__VA_ARGS__);                                               \
     POST_RET_##type(func_name)                                          \
     PRETEND_USED(flip_ret);                                             \

--- a/src/core/ibv/ibprof_ibv.c
+++ b/src/core/ibv/ibprof_ibv.c
@@ -710,7 +710,6 @@ static struct module_context_t {
 		HAVE_IBV_EXP_DEALLOC_MKEY_LIST_MEMORY_FUNC(TYPE)
 
 #define check_dlsym(_func)  check_dlsymv(_func, DEFAULT_SYMVER)
-#define check_dlsym_statement(_func) check_dlsym(_func);
 #define check_dlsymv(_func, _ver) \
 	do {                                                                \
 		ibv_module_context.noble._func = sys_dlsym(#_func, _ver);   \

--- a/src/core/ibv/ibprof_ibv.h
+++ b/src/core/ibv/ibprof_ibv.h
@@ -128,6 +128,7 @@
     EMPLOY_TYPE(func_name) *f;                                          \
     FUNC_BODY_RESOLVE##ctx_type(func_name, ex_name, ctx)                \
     PRE_##type(func_name)                                               \
+    INTERNAL_CHECK();                                                   \
     ret = f(__VA_ARGS__);                                               \
     POST_RET_##type(func_name)                                          \
     PRETEND_USED(flip_ret);                                             \
@@ -138,6 +139,7 @@
     EMPLOY_TYPE(func_name) *f;                                          \
     FUNC_BODY_RESOLVE##ctx_type(func_name, ex_name, ctx)                \
     PRE_##type(func_name)                                               \
+    INTERNAL_CHECK();                                                   \
     f(__VA_ARGS__);                                                     \
     POST_##type(func_name)                                              \
     PRETEND_USED(flip_ret);
@@ -148,6 +150,7 @@
     EMPLOY_TYPE(func_name) *f;                                          \
     FUNC_BODY_RESOLVE##ctx_type(func_name, ex_name, ctx)                \
     PRE_##type(func_name)                                               \
+    INTERNAL_CHECK();                                                   \
     ret = f(__VA_ARGS__);                                               \
     POST_RET_##type(func_name)                                          \
     PRETEND_USED(flip_ret);                                             \

--- a/src/core/mxm/ibprof_mxm.h
+++ b/src/core/mxm/ibprof_mxm.h
@@ -85,6 +85,7 @@
     EMPLOY_TYPE(func_name) *f;                                          \
     f = mxm_module_context.noble.func_name;                             \
     PRE_##type(func_name)                                               \
+    INTERNAL_CHECK();                                                   \
     ret = f(__VA_ARGS__);                                               \
     POST_RET_##type(func_name)                                          \
     PRETEND_USED(flip_ret);                                             \
@@ -95,6 +96,7 @@
     EMPLOY_TYPE(func_name) *f;                                          \
     f = mxm_module_context.noble.func_name;                             \
     PRE_##type(func_name)                                               \
+    INTERNAL_CHECK();                                                   \
     f(__VA_ARGS__);                                                     \
     POST_##type(func_name)                                              \
     PRETEND_USED(flip_ret);
@@ -105,6 +107,7 @@
     EMPLOY_TYPE(func_name) *f;                                          \
     f = mxm_module_context.noble.func_name;                             \
     PRE_##type(func_name)                                               \
+    INTERNAL_CHECK();                                                   \
     ret = f(__VA_ARGS__);                                               \
     POST_RET_##type(func_name)                                          \
     PRETEND_USED(flip_ret);                                             \


### PR DESCRIPTION
This fix solve cases we loading supported modules during run-time
using ldopen(). In this situation RTLD_NEXT can not help and we
need to load libraries to resolve symbols. This change helps when
supported library can be found under standart dlopen search places.
Use LD_LIBRARY_PATH to direct location when supported module (ibverbs,
mxm or hcol) was installed in nonstandard way.
This change does not cover situation when real application must use
module from specific place but libibprof finds one in another standard
location (use correct LD_LIBRARY_PATH as an workaround).
There is probably more friendly solution as rehook dlopen() inside but
it will be implemented later.

In addition this change provides --enable-check option (turned on by default) to check api calls. It avoids segmentation faults.
