### PR TITLE
Fix gcc warning

### DIFF
--- a/src/api/ibprof_api.c
+++ b/src/api/ibprof_api.c
@@ -68,7 +68,7 @@ pthread_once_t ibprof_initialized = PTHREAD_ONCE_INIT;
 #pragma GCC visibility push(default)
 #endif
 
-inline double ibprof_timestamp(void)
+double ibprof_timestamp(void)
 {
 #if defined(CONF_TIMESTAMP) && (CONF_TIMESTAMP == 1)
 	return ((double)sys_rdtsc() / __get_cpu_clocks_per_sec());

--- a/src/api/ibprof_api.h
+++ b/src/api/ibprof_api.h
@@ -45,7 +45,7 @@ enum {
  *
  * @retval (value) - time value in seconds
  ***************************************************************************/
-inline double ibprof_timestamp(void);
+double ibprof_timestamp(void);
 
 /**
  * ibprof_update


### PR DESCRIPTION
gcc 5.x reports warning as 'is static but used in inline function ...'
that is threated as an error

@miked-mellanox could you accept
