### PR TITLE
Add support for configurable output time units using IBPROF_TIME_UNITS

### DIFF
--- a/README
+++ b/README
@@ -21,7 +21,7 @@ summary of the calls from libibverbs.so, libmxm.so, libhcoll.so libraries.
 
 ===============================================================================================
 
-libibverbs                     :      count    total(ms)      avg(ms)      max(ms)      min(ms)
+libibverbs                     :        count     total        avg          max      min
 ===============================================================================================
 ibv_get_device_list            :          1       0.8897       0.8897       0.8897       0.8897
 ibv_free_device_list           :          1       0.0001       0.0001       0.0001       0.0001
@@ -52,7 +52,7 @@ Hello from task 4 on jenkins01!
 
 ===============================================================================================
 
-libibverbs                     :      count    total(ms)      avg(ms)      max(ms)      min(ms)
+libibverbs                     :        count     total        avg          max          min
 ===============================================================================================
 ibv_get_device_list            :          1       2.6830       2.6830       2.6830       2.6830
 ibv_free_device_list           :          1       0.0003       0.0003       0.0003       0.0003
@@ -156,6 +156,12 @@ ibv_poll_cq                    :        350       0.1092       0.0003       0.00
   Use following variable to exclude first <count>  of measurements from result
 
     $ export IBPROF_WARMUP_NUMBER=<count>
+
+  Set output time units using IBPROF_TIME_UNITS parameter, Possible values are:
+
+    0 - seconds
+    1 - milliseconds (default value)
+    2 - microseconds
 
 * How to use:
 

--- a/README
+++ b/README
@@ -21,7 +21,7 @@ summary of the calls from libibverbs.so, libmxm.so, libhcoll.so libraries.
 
 ===============================================================================================
 
-libibverbs                     :        count     total        avg          max      min
+libibverbs                     :      count    total(ms)      avg(ms)      max(ms)      min(ms)
 ===============================================================================================
 ibv_get_device_list            :          1       0.8897       0.8897       0.8897       0.8897
 ibv_free_device_list           :          1       0.0001       0.0001       0.0001       0.0001
@@ -52,7 +52,7 @@ Hello from task 4 on jenkins01!
 
 ===============================================================================================
 
-libibverbs                     :        count     total        avg          max          min
+libibverbs                     :      count    total(ms)      avg(ms)      max(ms)      min(ms)
 ===============================================================================================
 ibv_get_device_list            :          1       2.6830       2.6830       2.6830       2.6830
 ibv_free_device_list           :          1       0.0003       0.0003       0.0003       0.0003

--- a/src/cmn/ibprof_cmn.h
+++ b/src/cmn/ibprof_cmn.h
@@ -154,6 +154,19 @@ enum {
 	IBPROF_LOG_TRACE = 1 << 4
 };
 
+enum {
+	IBPROF_TIME_UNITS_SEC = 0, // First
+	IBPROF_TIME_UNITS_MSEC,
+	IBPROF_TIME_UNITS_USEC,
+	IBPROF_TIME_UNITS_LAST
+};
+
+static const char * const ibprof_time_units_str[] = {
+  "seconds",
+  "milliseconds",
+  "microseconds",
+};
+
 #define IBPROF_FATAL(fmt, ...)                                       \
 	do {                                                             \
 		if (ibprof_conf_get_int(IBPROF_TEST_MASK) & IBPROF_LOG_FATAL) \

--- a/src/cmn/ibprof_cmn.h
+++ b/src/cmn/ibprof_cmn.h
@@ -167,6 +167,12 @@ static const char * const ibprof_time_units_str[] = {
   "microseconds",
 };
 
+static long const ibprof_time_units_multiplier_val[] = {
+  1,        // seconds
+  1000,     // milliseconds
+  1000000,  // microseconds
+};
+
 #define IBPROF_FATAL(fmt, ...)                                       \
 	do {                                                             \
 		if (ibprof_conf_get_int(IBPROF_TEST_MASK) & IBPROF_LOG_FATAL) \

--- a/src/cmn/ibprof_cmn.h
+++ b/src/cmn/ibprof_cmn.h
@@ -167,6 +167,12 @@ static const char * const ibprof_time_units_str[] = {
   "microseconds",
 };
 
+static const char * const ibprof_time_units_short_str[] = {
+  "s ",
+  "ms",
+  "us",
+};
+
 static long const ibprof_time_units_multiplier_val[] = {
   1,        // seconds
   1000,     // milliseconds

--- a/src/core/ibprof_conf.c
+++ b/src/core/ibprof_conf.c
@@ -34,6 +34,7 @@ void ibprof_conf_init(void)
 	static const char *ibprof_format = NULL;
 	static int ibprof_err_percent = 1;
 	static int ibprof_err_seed = 1337;
+	static int ibprof_time_units = IBPROF_TIME_UNITS_MSEC;
 
 	enviroment[IBPROF_TEST_MASK] = (void *) &ibprof_test_mask;
 	enviroment[IBPROF_MODE_IBV] = (void *) &ibprof_mode_ibv;
@@ -47,6 +48,7 @@ void ibprof_conf_init(void)
 	enviroment[IBPROF_FORMAT] = (void *) ibprof_format;
 	enviroment[IBPROF_ERR_PERCENT] = (void *) &ibprof_err_percent;
 	enviroment[IBPROF_ERR_SEED] = (void *) &ibprof_err_seed;
+	enviroment[IBPROF_TIME_UNITS] = (void *) &ibprof_time_units;
 
 	_ibprof_conf_init();
 }
@@ -100,6 +102,13 @@ static void _ibprof_conf_init(void)
 	if (env) {
 		*(int *) enviroment[IBPROF_ERR_SEED] = sys_strtol(env, NULL, 0);
 		srand(*(int *) enviroment[IBPROF_ERR_SEED]);
+	}
+
+	env = getenv("IBPROF_TIME_UNITS");
+	if (env) {
+		uint8_t val = sys_strtol(env, NULL, 0);
+		if (val < IBPROF_TIME_UNITS_LAST)
+			*(int *) enviroment[IBPROF_TIME_UNITS] = val;
 	}
 }
 
@@ -231,4 +240,9 @@ int ibprof_conf_get_mode(int module)
 	}
 
 	return mode;
+}
+
+const char* ibprof_conf_get_time_units()
+{
+	return ibprof_time_units_str[*(int *) enviroment[IBPROF_TIME_UNITS]];
 }

--- a/src/core/ibprof_conf.c
+++ b/src/core/ibprof_conf.c
@@ -241,8 +241,3 @@ int ibprof_conf_get_mode(int module)
 
 	return mode;
 }
-
-const char* ibprof_conf_get_time_units()
-{
-	return ibprof_time_units_str[*(int *) enviroment[IBPROF_TIME_UNITS]];
-}

--- a/src/core/ibprof_conf.h
+++ b/src/core/ibprof_conf.h
@@ -37,6 +37,4 @@ int ibprof_conf_get_int(IBPROF_ENV variable);
 
 int ibprof_conf_get_mode(int module);
 
-const char* ibprof_conf_get_time_units();
-
 #endif /* _IBPROF_ENV_H_ */

--- a/src/core/ibprof_conf.h
+++ b/src/core/ibprof_conf.h
@@ -24,6 +24,7 @@ typedef enum {
 	IBPROF_FORMAT,
 	IBPROF_ERR_PERCENT,
 	IBPROF_ERR_SEED,
+	IBPROF_TIME_UNITS,
 
 	IBPROF_ENV_OPTIONS_AMOUNT
 } IBPROF_ENV;
@@ -35,5 +36,7 @@ char* ibprof_conf_get_string(IBPROF_ENV variable);;
 int ibprof_conf_get_int(IBPROF_ENV variable);
 
 int ibprof_conf_get_mode(int module);
+
+const char* ibprof_conf_get_time_units();
 
 #endif /* _IBPROF_ENV_H_ */

--- a/src/core/ibprof_hash.c
+++ b/src/core/ibprof_hash.c
@@ -8,6 +8,8 @@
  * $HEADER$
  */
 
+#include <math.h>
+
 #include "ibprof_cmn.h"
 #include "ibprof_conf.h"
 #include "ibprof_api.h"
@@ -15,7 +17,12 @@
 
 #include "ibprof_hash.h"
 
-#define TO_TIME(t_val) ((t_val) * 1000)
+static double to_time(double t_val)
+{
+	static long time_units_multiplier;
+	time_units_multiplier = pow(1000, ibprof_conf_get_int(IBPROF_TIME_UNITS));
+	return t_val * time_units_multiplier;
+}
 
 /****************************************************************************
  * Static Function Declarations
@@ -81,7 +88,7 @@ void ibprof_hash_destroy(IBPROF_HASH_OBJECT *hash_obj)
  * ibprof_hash_module_total
  *
  * @brief
- *    Dump total collected time in ms for module.
+ *    Dump total collected time for module.
  *
  * @return formatted string
  ***************************************************************************/
@@ -99,7 +106,7 @@ double ibprof_hash_module_total(IBPROF_HASH_OBJECT *hash_obj,
 			if (rank != HASH_KEY_GET_RANK(hash_obj->hash_table[i].key))
 				continue;
 
-			result_total += TO_TIME(hash_obj->hash_table[i].t_tot);
+			result_total += to_time(hash_obj->hash_table[i].t_tot);
 		}
 	}
 
@@ -171,11 +178,11 @@ char *ibprof_hash_dump(IBPROF_HASH_OBJECT *hash_obj,
 							(buffer_len - dest_len), "%s",
 							format(module, call_name, "%ld %f %f %f %f %ld",
 							hash_obj->hash_table[i].count,
-	                        TO_TIME(hash_obj->hash_table[i].t_tot),
+	                        to_time(hash_obj->hash_table[i].t_tot),
 	                        (hash_obj->hash_table[i].count > 0 ? 
-					TO_TIME(hash_obj->hash_table[i].t_tot) / (hash_obj->hash_table[i].count - ibprof_conf_get_int(IBPROF_WARMUP_NUMBER)) : 0),
-	                        TO_TIME(hash_obj->hash_table[i].t_max),
-	                        (hash_obj->hash_table[i].count > 0 ? TO_TIME(hash_obj->hash_table[i].t_min) : 0),
+					to_time(hash_obj->hash_table[i].t_tot) / (hash_obj->hash_table[i].count - ibprof_conf_get_int(IBPROF_WARMUP_NUMBER)) : 0),
+	                        to_time(hash_obj->hash_table[i].t_max),
+	                        (hash_obj->hash_table[i].count > 0 ? to_time(hash_obj->hash_table[i].t_min) : 0),
 							hash_obj->hash_table[i].mode_data.err));
 				break;
 
@@ -184,11 +191,11 @@ char *ibprof_hash_dump(IBPROF_HASH_OBJECT *hash_obj,
 							(buffer_len - dest_len), "%s",
 							format(module, call_name, "%ld %f %f %f %f",
 							hash_obj->hash_table[i].count,
-	                        TO_TIME(hash_obj->hash_table[i].t_tot),
+	                        to_time(hash_obj->hash_table[i].t_tot),
 	                        (hash_obj->hash_table[i].count > 0 ?
-					TO_TIME(hash_obj->hash_table[i].t_tot) / (hash_obj->hash_table[i].count - ibprof_conf_get_int(IBPROF_WARMUP_NUMBER)) : 0),
-	                        TO_TIME(hash_obj->hash_table[i].t_max),
-	                        (hash_obj->hash_table[i].count > 0 ? TO_TIME(hash_obj->hash_table[i].t_min) : 0)));
+					to_time(hash_obj->hash_table[i].t_tot) / (hash_obj->hash_table[i].count - ibprof_conf_get_int(IBPROF_WARMUP_NUMBER)) : 0),
+	                        to_time(hash_obj->hash_table[i].t_max),
+	                        (hash_obj->hash_table[i].count > 0 ? to_time(hash_obj->hash_table[i].t_min) : 0)));
 				break;
 			}
 			if (ret >= 0) {

--- a/src/core/ibprof_hash.c
+++ b/src/core/ibprof_hash.c
@@ -8,8 +8,6 @@
  * $HEADER$
  */
 
-#include <math.h>
-
 #include "ibprof_cmn.h"
 #include "ibprof_conf.h"
 #include "ibprof_api.h"
@@ -20,7 +18,7 @@
 static double to_time(double t_val)
 {
 	static long time_units_multiplier;
-	time_units_multiplier = pow(1000, ibprof_conf_get_int(IBPROF_TIME_UNITS));
+	time_units_multiplier = ibprof_time_units_multiplier_val[ibprof_conf_get_int(IBPROF_TIME_UNITS)];
 	return t_val * time_units_multiplier;
 }
 

--- a/src/core/ibprof_hash.h
+++ b/src/core/ibprof_hash.h
@@ -205,7 +205,7 @@ static INLINE void ibprof_hash_update_ex(IBPROF_HASH_OBJECT *hash_obj,
  * ibprof_hash_module_total
  *
  * @brief
- *    Dump total collected time in ms for module.
+ *    Dump total collected time for module.
  *
  * @return formatted string
  ***************************************************************************/

--- a/src/core/io/ibprof_plain.c
+++ b/src/core/io/ibprof_plain.c
@@ -93,7 +93,7 @@ static void _ibprof_banner_dump(FILE* file, IBPROF_OBJECT *ibprof_obj)
 
 	_ibprof_task_dump(ibprof_obj->task_obj);
 	plain_output(file,"warmup number : %d\n", ibprof_conf_get_int(IBPROF_WARMUP_NUMBER));
-	plain_output(file,"Output time units : %s\n", ibprof_time_units_str[ibprof_conf_get_int(IBPROF_TIME_UNITS)]);
+	plain_output(file,"Output time unit : %s\n", ibprof_time_units_str[ibprof_conf_get_int(IBPROF_TIME_UNITS)]);
 	plain_output(file, DELIMITER);
 
 	return;
@@ -163,19 +163,23 @@ static void _ibprof_module_dump(FILE* file, IBPROF_MODULE_OBJECT *module_obj, IB
 {
 	const IBPROF_MODULE_CALL *temp_module_call = NULL;
 	char *str = NULL;
+	const char *time_unit = ibprof_time_units_short_str[ibprof_conf_get_int(IBPROF_TIME_UNITS)];
 
 	plain_output(file, "\n");
 	switch (ibprof_conf_get_mode(module_obj->id)) {
 	case IBPROF_MODE_ERR:
-		plain_output(file, "%-30.30s : %10s   %10s   %10s   %10s   %10s   %10s\n",
+		plain_output(file, "%-30.30s : %10s   %6s(%2s)   %6s(%2s)   %6s(%2s)   %6s(%2s)   %10s\n",
 			(module_obj->name ? module_obj->name : "unknown"), "count",
-						"total", "avg", "max", "min", "fail");
+						"total", time_unit, "avg", time_unit,
+						"max", time_unit, "min", time_unit, "fail");
 		break;
 
 	default:
-		plain_output(file, "%-30.30s : %10s   %10s   %10s   %10s   %10s\n",
+
+		plain_output(file, "%-30.30s : %10s   %6s(%2s)   %6s(%2s)   %6s(%2s)   %6s(%2s)\n",
 			(module_obj->name ? module_obj->name : "unknown"), "count",
-						"total", "avg", "max", "min");
+						"total", time_unit, "avg", time_unit,
+						"max", time_unit, "min", time_unit);
 		break;
 	}
 	plain_output(file, DELIMITER);

--- a/src/core/io/ibprof_plain.c
+++ b/src/core/io/ibprof_plain.c
@@ -93,7 +93,7 @@ static void _ibprof_banner_dump(FILE* file, IBPROF_OBJECT *ibprof_obj)
 
 	_ibprof_task_dump(ibprof_obj->task_obj);
 	plain_output(file,"warmup number : %d\n", ibprof_conf_get_int(IBPROF_WARMUP_NUMBER));
-	plain_output(file,"Output time units : %s\n", ibprof_conf_get_time_units());
+	plain_output(file,"Output time units : %s\n", ibprof_time_units_str[ibprof_conf_get_int(IBPROF_TIME_UNITS)]);
 	plain_output(file, DELIMITER);
 
 	return;

--- a/src/core/io/ibprof_plain.c
+++ b/src/core/io/ibprof_plain.c
@@ -41,7 +41,7 @@ void ibprof_io_plain_dump(FILE* file, IBPROF_OBJECT *ibprof_obj)
 {
 	IBPROF_MODULE_OBJECT *temp_module_obj = NULL;
 	int i = 0;
-	double total_time_in_ms = 0;
+	double total_time = 0;
 
 	if (ibprof_conf_get_int(IBPROF_OUTPUT_PREFIX)) {
 		plain_output = _ibprof_io_plain_prefix;
@@ -62,13 +62,13 @@ void ibprof_io_plain_dump(FILE* file, IBPROF_OBJECT *ibprof_obj)
 
 			_ibprof_module_dump(file, temp_module_obj, ibprof_obj->hash_obj, ibprof_obj->task_obj->procid);
 
-			total_time_in_ms = ibprof_hash_module_total(ibprof_obj->hash_obj,
+			total_time = ibprof_hash_module_total(ibprof_obj->hash_obj,
 				temp_module_obj->id,
 				ibprof_obj->task_obj->procid);
 
-			plain_output(file, "%-30.30s :    %20.4f\n", "total", total_time_in_ms);
+			plain_output(file, "%-30.30s :    %20.4f\n", "total", total_time);
 			plain_output(file, DELIMITER);
-			plain_output(file, "%-30.30s :    %20.4f %\n", "wall time (%)", total_time_in_ms
+			plain_output(file, "%-30.30s :    %20.4f %\n", "wall time (%)", total_time
 				/ (ibprof_obj->task_obj->wall_time * 1.0e+6));
 			plain_output(file, DELIMITER);
 		}
@@ -93,6 +93,7 @@ static void _ibprof_banner_dump(FILE* file, IBPROF_OBJECT *ibprof_obj)
 
 	_ibprof_task_dump(ibprof_obj->task_obj);
 	plain_output(file,"warmup number : %d\n", ibprof_conf_get_int(IBPROF_WARMUP_NUMBER));
+	plain_output(file,"Output time units : %s\n", ibprof_conf_get_time_units());
 	plain_output(file, DELIMITER);
 
 	return;
@@ -168,13 +169,13 @@ static void _ibprof_module_dump(FILE* file, IBPROF_MODULE_OBJECT *module_obj, IB
 	case IBPROF_MODE_ERR:
 		plain_output(file, "%-30.30s : %10s   %10s   %10s   %10s   %10s   %10s\n",
 			(module_obj->name ? module_obj->name : "unknown"), "count",
-						"total(ms)", "avg(ms)", "max(ms)", "min(ms)", "fail");
+						"total", "avg", "max", "min", "fail");
 		break;
 
 	default:
 		plain_output(file, "%-30.30s : %10s   %10s   %10s   %10s   %10s\n",
 			(module_obj->name ? module_obj->name : "unknown"), "count",
-						"total(ms)", "avg(ms)", "max(ms)", "min(ms)");
+						"total", "avg", "max", "min");
 		break;
 	}
 	plain_output(file, DELIMITER);

--- a/src/core/io/ibprof_xml.c
+++ b/src/core/io/ibprof_xml.c
@@ -97,7 +97,7 @@ static int _ibprof_banner_dump(char **root, IBPROF_OBJECT *ibprof_obj)
 					XML("copyright", "%s") \
 					XML("task", "%s") \
 					XML("warmup_number", "%d") \
-					XML("Output time units", "%s")
+					XML("Output time unit", "%s")
 				)
 			),
 			__MODULE_NAME,

--- a/src/core/io/ibprof_xml.c
+++ b/src/core/io/ibprof_xml.c
@@ -96,7 +96,8 @@ static int _ibprof_banner_dump(char **root, IBPROF_OBJECT *ibprof_obj)
 					XML("compiled_time", "%s") \
 					XML("copyright", "%s") \
 					XML("task", "%s") \
-					XML("warmup_number", "%d")
+					XML("warmup_number", "%d") \
+					XML("Output time units", "%s")
 				)
 			),
 			__MODULE_NAME,
@@ -105,7 +106,8 @@ static int _ibprof_banner_dump(char **root, IBPROF_OBJECT *ibprof_obj)
 			__TIME__,
 			__MODULE_COPYRIGHT,
 			task_dump,
-			ibprof_conf_get_int(IBPROF_WARMUP_NUMBER));
+			ibprof_conf_get_int(IBPROF_WARMUP_NUMBER),
+			ibprof_conf_get_time_units());
 	}
 
 	sys_free(task_dump);
@@ -161,10 +163,10 @@ static const char *_ibprof_hash_format_xml(int module, const char* call_name, co
 	ret = sys_vsnprintf(stat_buffer,
 		sizeof(buffer),
 		XML("count", "%ld") \
-		XML("total_ms", "%.4f") \
-		XML("avg_ms", "%.4f") \
-		XML("max_ms", "%.4f") \
-		XML("min_ms", "%.4f") \
+		XML("total", "%.4f") \
+		XML("avg", "%.4f") \
+		XML("max", "%.4f") \
+		XML("min", "%.4f") \
 		XML("fail", "%ld"),
 		stats);
 	if (ret >= 0)
@@ -191,7 +193,7 @@ static int _ibprof_module_dump(char **module, IBPROF_MODULE_OBJECT *module_obj, 
 {
 	const IBPROF_MODULE_CALL *temp_module_call = NULL;
 	char *str = NULL;
-	double total_time_in_ms = 0;
+	double total_time = 0;
 	char *module_calls = NULL;
 	int ret = 0;
 
@@ -239,7 +241,7 @@ static int _ibprof_module_dump(char **module, IBPROF_MODULE_OBJECT *module_obj, 
 			free(str);
 	}
 
-	total_time_in_ms = ibprof_hash_module_total(hash_obj,
+	total_time = ibprof_hash_module_total(hash_obj,
 		module_obj->id,
 		task_obj->procid);
 
@@ -251,8 +253,8 @@ static int _ibprof_module_dump(char **module, IBPROF_MODULE_OBJECT *module_obj, 
 			XML("wall_time_percent", "%.4f")),
 			module_obj->name ? module_obj->name : "unknown",
 			module_calls,
-			total_time_in_ms,
-			total_time_in_ms / (task_obj->wall_time * 1.0e+6));
+			total_time,
+			total_time / (task_obj->wall_time * 1.0e+6));
 
 	sys_free(module_calls);
 

--- a/src/core/io/ibprof_xml.c
+++ b/src/core/io/ibprof_xml.c
@@ -107,7 +107,7 @@ static int _ibprof_banner_dump(char **root, IBPROF_OBJECT *ibprof_obj)
 			__MODULE_COPYRIGHT,
 			task_dump,
 			ibprof_conf_get_int(IBPROF_WARMUP_NUMBER),
-			ibprof_conf_get_time_units());
+			ibprof_time_units_str[ibprof_conf_get_int(IBPROF_TIME_UNITS)]);
 	}
 
 	sys_free(task_dump);


### PR DESCRIPTION
parameter. Possible values are:
  0 - seconds
  1 - milliseconds (default value)
  2 - microseconds

Signed-off-by: Liran Oz <lirano@mellanox.com>