### PR TITLE
Link with pthread to fix segfault error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AC_CONFIG_MACRO_DIR([config/m4])
 LT_INIT
 CFLAGS="$CFLAGS -Wall -Werror"
 CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE -D__LINUX__ -D__MODULE_VERSION=$VERSION"
+LDFLAGS="$LDFLAGS -lpthread"
 
 ##########################
 # Compile with OpenFabrics

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,6 @@ AC_CONFIG_MACRO_DIR([config/m4])
 LT_INIT
 CFLAGS="$CFLAGS -Wall -Werror"
 CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE -D__LINUX__ -D__MODULE_VERSION=$VERSION"
-LDFLAGS="$LDFLAGS -lpthread"
 
 ##########################
 # Compile with OpenFabrics
@@ -106,6 +105,9 @@ AC_CHECK_LIB([dl], [dlopen],
     [LIBS="$LIBS -ldl"],
     [AC_MSG_ERROR([libdl not found])])
 
+AC_CHECK_LIB([pthread], [pthread_create], 
+    [LIBS="$LIBS -lpthread"],
+    [AC_MSG_ERROR([pthread not found])])
 
 AC_HEADER_STDC
 


### PR DESCRIPTION
To profile [SparkRDMA](https://github.com/Mellanox/SparkRDMA) on the distributed environment just setting up globally `export LD_PRELOAD=libibprof.so`, to not link and rebuild disni (or any other library, that uses verbs). This fails with a segfault:
```
     27750:     /hpc/scrap/users/swat/jenkins/profile/libibprof/lib/libibprof.so: error: symbol lookup error: undefined symbol: pthread_mutexattr_init (fatal)
```